### PR TITLE
Add section describing nowdoc and heredoc

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1076,6 +1076,72 @@ $instance = new class extends \Foo implements
 };
 ~~~
 
+## 9. Heredoc and Nowdoc
+
+A nowdoc SHOULD be used wherever possible. Heredoc MAY be used when a nowdoc
+does not satisfy requirements.
+
+Heredoc and nowdoc syntax is largely governed by PHP requirements with the only
+allowed variation being indentation. Declared heredocs or nowdocs MUST
+begin on the same line as the context the declaration is being used in.
+Subsequent lines in the heredoc or nowdoc MUST be indented once past the scope
+indentation they are declared in.
+
+The following is ***not allowed*** due to the heredoc beginning on a
+different line than the context it's being declared in:
+```php
+$notAllowed =
+<<<'COUNTEREXAMPLE'
+    This
+    is
+    not
+    allowed.
+    COUNTEREXAMPLE;
+```
+
+Instead the heredoc MUST be declared on the same line as the variable
+declaration it's being set against.
+
+The follow is ***not allowed*** due to the scope indention not matching the scope the
+heredoc is declared in:
+```php
+function notAllowed()
+{
+    $notAllowed = <<<'COUNTEREXAMPLE'
+This
+is
+not
+allowed.
+COUNTEREXAMPLE
+}
+```
+
+Instead, the heredoc MUST be indented once past the indentation of the scope
+it's declared in.
+
+The following is an example of both a heredoc and a nowdoc declared in a
+compliant way:
+```php
+function allowed()
+{
+    $allowed = <<<COMPLIANT
+        This
+        is
+        a
+        compliant
+        heredoc
+        COMPLIANT;
+
+    $allowedNowdoc = <<<'COMPLIANT'
+        This
+        is
+        a
+        compliant
+        heredoc
+        COMPLIANT;
+}
+```
+
 [PSR-1]: https://www.php-fig.org/psr/psr-1/
 [PSR-2]: https://www.php-fig.org/psr/psr-2/
 [keywords]: http://php.net/manual/en/reserved.keywords.php


### PR DESCRIPTION
This PR adds the beginnings of a section that describes the usage of heredoc / nowdoc statements. I don't necessarily expect the rules contained in this PR to be accepted without discussion but I wanted to get something down to kick-start discussion.

Potentially contentious points:
1. Nowdoc recommended over heredoc. We intentionally tried to avoid SHOULD in PSR-12 since SHOULD isn't a very good basis for a code style guide. However I think this is a place where it makes sense for us to recommend folks don't use heredocs where nowdocs are more appropriate since it's not a matter of codestyle, more a matter of best practices. That said, maybe this should be left out and we should instead focus on things that are strictly codestyle and not related to potential misuse.
2. Heredoc / nowdoc declared on the same line as the context it's being declared into. This idea is really hard to put into words but basically the thinking is we don't want folks to add a newline between the `=` and the nowdoc / heredoc declaration when assigning a heredoc to a variable, and we don't want heredoc to modify how function arguments are provided and so this rule attempts to require the implementor to put the heredoc opening on the same line as the context using it always. To be clear it's totally fine to use a heredoc / nowdoc in a multiline function / method call, it's just that the heredoc opening itself should not command it's own line if not otherwise required.
3. Indent heredocs once time past the current scope. I'd wager most heredocs today are not indented at all and so this is probably a big departure from what most people are used to. I think it's definitely better to have the heredoc / nowdoc indented to at least match the current scope rather than have it lack any indention at all.