### PR TITLE
Add section on enumerations.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1094,7 +1094,7 @@ $instance = new class extends \Foo implements
 
 ## 9. Enumerations
 
-Enumerations (enums) MUST follow the same guidelines as classes, except where otherwise noted here.
+Enumerations (enums) MUST follow the same guidelines as classes, except where otherwise noted below.
 
 Methods in enums MUST follow the same guidelines as methods in classes.  Non-public methods MUST use `private`
 instead of `protected`, as enums do not support inheritance.
@@ -1105,7 +1105,7 @@ space between the colon and the backing type.  This is consistent with the style
 Enum case declarations MUST use CamelCase capitalization.  Enum case declarations MUST be on their own line.
 
 Constants in Enumerations MAY use either CamelCase or UPPER_CASE capitalization.  CamelCase is RECOMMENDED,
-so that it is consistent with cases.
+so that it is consistent with case declarations.
 
 ```php
 enum Suit: string

--- a/spec.md
+++ b/spec.md
@@ -68,6 +68,17 @@ class Foo extends Bar implements FooInterface
         // method body
     }
 }
+
+Enum Beep: int
+{
+    case A = 1;
+    case B = 2;
+
+    public function isOdd(): bool
+    {
+        return $this->value() % 2;
+    }
+}
 ```
 
 ## 2. General
@@ -233,7 +244,7 @@ declare(ticks=1) {
 
 ## 4. Classes, Properties, and Methods
 
-The term "class" refers to all classes, interfaces, and traits.
+The term "class" refers to all classes, interfaces, traits, and enums.
 
 Any closing brace MUST NOT be followed by any comment or statement on the
 same line.
@@ -1083,20 +1094,18 @@ $instance = new class extends \Foo implements
 
 ## 9. Enumerations
 
-Enumerations MUST follow the same guidelines as classes, except where otherwise noted here.
+Enumerations (enums) MUST follow the same guidelines as classes, except where otherwise noted here.
 
-Methods in Enumerations MUST follow the same guidelines as methods in classes.  Non-public methods MUST use `private`
-instead of `protected`.
+Methods in enums MUST follow the same guidelines as methods in classes.  Non-public methods MUST use `private`
+instead of `protected`, as enums do not support inheritance.
 
-In the case of a backed enum, there MUST NOT be a space between the enum name and colon, and there MUST be exactly one
-space between the colon and the backing type.
+When using a backed enum, there MUST NOT be a space between the enum name and colon, and there MUST be exactly one
+space between the colon and the backing type.  This is consistent with the style for return types.
 
-Enumeration cases MUST use CamelCase capitalization.
+Enum case declarations MUST use CamelCase capitalization.  Enum case declarations MUST be on their own line.
 
 Constants in Enumerations MAY use either CamelCase or UPPER_CASE capitalization.  CamelCase is RECOMMENDED,
 so that it is consistent with cases.
-
-No more than one case is permitted per line.
 
 ```php
 enum Suit: string

--- a/spec.md
+++ b/spec.md
@@ -1081,6 +1081,36 @@ $instance = new class extends \Foo implements
 };
 ```
 
+## 9. Enumerations
+
+Enumerations MUST follow the same guidelines as classes, except where otherwise noted here.
+
+Methods in Enumerations MUST follow the same guidelines as methods in classes.  Non-public methods MUST use `private`
+instead of `protected`.
+
+In the case of a backed enum, there MUST NOT be a space between the enum name and colon, and there MUST be exactly one
+space between the colon and the backing type.
+
+Enumeration cases MUST use CamelCase capitalization.
+
+Constants in Enumerations MAY use either CamelCase or UPPER_CASE capitalization.  CamelCase is RECOMMENDED,
+so that it is consistent with cases.
+
+No more than one case is permitted per line.
+
+```php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Spades = 'S';
+    case Clubs = 'C';
+
+    const Wild = self::Spades;
+}
+
+```
+
 [PSR-1]: https://www.php-fig.org/psr/psr-1/
 [PSR-12]: https://www.php-fig.org/psr/psr-12/
 [keywords]: http://php.net/manual/en/reserved.keywords.php

--- a/spec.md
+++ b/spec.md
@@ -1104,7 +1104,7 @@ space between the colon and the backing type.  This is consistent with the style
 
 Enum case declarations MUST use CamelCase capitalization.  Enum case declarations MUST be on their own line.
 
-Constants in Enumerations MAY use either CamelCase or UPPER_CASE capitalization.  CamelCase is RECOMMENDED,
+Constants in Enumerations MAY use either PascalCase or UPPER_CASE capitalization. PascalCase is RECOMMENDED,
 so that it is consistent with case declarations.
 
 ```php

--- a/spec.md
+++ b/spec.md
@@ -71,8 +71,8 @@ class Foo extends Bar implements FooInterface
 
 Enum Beep: int
 {
-    case A = 1;
-    case B = 2;
+    case Foo = 1;
+    case Bar = 2;
 
     public function isOdd(): bool
     {


### PR DESCRIPTION
It occurs to me that there is no mention of constant capitalization anywhere else, but IMO constants in enums really should use CamelCase for consistency.  (Frankly they should elsewhere, and I do use them that way elsewhere.)  I don't know if we want to also mention constants more broadly.