### PR TITLE
Add method chaining style specification

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -649,6 +649,16 @@ $app->get('/hello/{name}', function ($name) use ($app) {
 });
 ```
 
+Method chaining SHOULD be put on separate lines, where each subsequent line is indented once. When doing so, the first
+method MUST be on the next line.
+
+```php
+$someInstance
+    ->create()
+    ->prepare()
+    ->run();
+```
+
 ## 5. Control Structures
 
 The general style rules for control structures are as follows:

--- a/spec.md
+++ b/spec.md
@@ -649,7 +649,7 @@ $app->get('/hello/{name}', function ($name) use ($app) {
 });
 ```
 
-Method chaining SHOULD be put on separate lines, where each subsequent line is indented once. When doing so, the first
+Method chaining MAY be put on separate lines, where each subsequent line is indented once. When doing so, the first
 method MUST be on the next line.
 
 ```php


### PR DESCRIPTION
PR is inspired by https://github.com/yiisoft/docs/issues/155

Placing methods in a chain of methods on separate lines is more readable in most cases. In rare cases, this is not the case, so SHOULD.