### PR TITLE
Update the abstract/final section to cover all modifier keywords

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -579,13 +579,19 @@ public function process(string $algorithm, &...$parts)
 }
 ```
 
-### 4.6 `abstract`, `final`, and `static`
+### 4.6 Modifier keywords
 
-When present, the `abstract` and `final` declarations MUST precede the
-visibility declaration.
+Properties and methods of a class have numerous keyword modifiers that alter how the
+engine and language handles them.  When present, they MUST be in the following order:
 
-When present, the `static` declaration MUST come after the visibility
-declaration.
+* Inheritance modifier: `abstract` or `final`
+* Visibility modifier: `public`, `protected`, or `private`
+* Scope modifier: `static`
+* Mutation modifier: `readonly`
+* Type declaration
+* Name
+
+All keywords MUST be on a single line, and MUST be separated by a single space.
 
 ```php
 <?php
@@ -594,7 +600,9 @@ namespace Vendor\Package;
 
 abstract class ClassName
 {
-    protected static $foo;
+    protected static readonly string $foo;
+
+    final protected int $beep;
 
     abstract protected function zim();
 

--- a/spec.md
+++ b/spec.md
@@ -611,6 +611,11 @@ abstract class ClassName
         // method body
     }
 }
+
+readonly class ValueObject
+{
+    // ...
+}
 ```
 
 ### 4.7 Method and Function Calls

--- a/spec.md
+++ b/spec.md
@@ -579,7 +579,7 @@ public function process(string $algorithm, &...$parts)
 }
 ```
 
-### 4.6 Modifier keywords
+### 4.6 Modifier Keywords
 
 Properties and methods of a class have numerous keyword modifiers that alter how the
 engine and language handles them.  When present, they MUST be in the following order:


### PR DESCRIPTION
This covers a couple of new additions: `readonly`, typed properties, etc. Because there's so many, it made sense to me to repurpose the abstract/final/static section to cover the full list, in order.

This may overlap now with section 4.4.  If so, I recommend agreeing on the rules (this PR), then we can refactor the spec text to be better chunked if needed.