### PR TITLE
fix: Unify the usage of () after class instances (including anonymous classes)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1055,24 +1055,27 @@ in the above section.
 ```php
 <?php
 
-$instance = new class {};
-```
+$instance = new class () {};
+~~~
 
 The opening brace MAY be on the same line as the `class` keyword so long as
 the list of `implements` interfaces does not wrap. If the list of interfaces
 wraps, the brace MUST be placed on the line immediately following the last
 interface.
 
+This also includes the use of parentheses due to directly instantiating the 
+declared class.
+
 ```php
 <?php
 
 // Brace on the same line
-$instance = new class extends \Foo implements \HandleableInterface {
+$instance = new class () extends \Foo implements \HandleableInterface {
     // Class content
 };
 
 // Brace on the next line
-$instance = new class extends \Foo implements
+$instance = new class () extends \Foo implements
     \ArrayAccess,
     \Countable,
     \Serializable

--- a/spec.md
+++ b/spec.md
@@ -1056,7 +1056,7 @@ in the above section.
 <?php
 
 $instance = new class () {};
-~~~
+```
 
 The opening brace MAY be on the same line as the `class` keyword so long as
 the list of `implements` interfaces does not wrap. If the list of interfaces


### PR DESCRIPTION
According to chapter 4:

> ## 4. Classes, Properties, and Methods
>
> The term "class" refers to all classes, interfaces, and traits.
>
> Any closing brace MUST NOT be followed by any comment or statement on the same line.
>
> When instantiating a new class, parentheses MUST always be present even when there are no arguments passed to the constructor.

This MR updates the spec to adhere to that rule on anonymous classes too.
(taken from moved from [php-fig/!1283](https://github.com/php-fig/fig-standards/pull/1283))

The original MR on PHP-Fig also mentioned short closures but [!17](https://github.com/php-fig/per-coding-style/pull/17) already fixes this.