### PR TITLE
Update link to RFC 2119

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4,7 +4,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[RFC 2119]: http://datatracker.ietf.org/doc/html/rfc2119
 
 ## Overview
 


### PR DESCRIPTION
The link we currently have is 404 for some reason, this new URL is the one I get directed to from google.