### PR TITLE
Fix firs capital letter in `enum` declaration example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -69,7 +69,7 @@ class Foo extends Bar implements FooInterface
     }
 }
 
-Enum Beep: int
+enum Beep: int
 {
     case Foo = 1;
     case Bar = 2;


### PR DESCRIPTION
A think there is a little mistake.