### PR TITLE
Omit () on zero-argument anonymous classes.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1187,20 +1187,25 @@ the list of `implements` interfaces does not wrap. If the list of interfaces
 wraps, the brace MUST be placed on the line immediately following the last
 interface.
 
+If the anonymous class has no arguments, the `()` after `class` MUST be omitted.
+
 ```php
 <?php
 
 // Brace on the same line
+// No arguments
 $instance = new class extends \Foo implements \HandleableInterface {
     // Class content
 };
 
 // Brace on the next line
-$instance = new class extends \Foo implements
+// Constructor arguments
+$instance = new class($a) extends \Foo implements
     \ArrayAccess,
     \Countable,
     \Serializable
 {
+    public function __construct(public int $a) {}
     // Class content
 };
 ```

--- a/spec.md
+++ b/spec.md
@@ -1205,7 +1205,9 @@ $instance = new class($a) extends \Foo implements
     \Countable,
     \Serializable
 {
-    public function __construct(public int $a) {}
+    public function __construct(public int $a)
+    {
+    }
     // Class content
 };
 ```


### PR DESCRIPTION
Replaces #24 