### PR TITLE
Clarify that classes should follow the same modifier order as methods.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -633,7 +633,7 @@ public function process(string $algorithm, &...$parts)
 
 ### 4.6 Modifier Keywords
 
-Properties and methods of a class have numerous keyword modifiers that alter how the
+Classes, properties, and methods have numerous keyword modifiers that alter how the
 engine and language handles them.  When present, they MUST be in the following order:
 
 * Inheritance modifier: `abstract` or `final`


### PR DESCRIPTION
This effectively covers readonly classes in PHP 8.2, because the order of `readonly` and `abstract` is already defined.  It also means any future keywords added to either can follow the same ruleset, so we know exactly what is to be expected.