### PR TITLE
Allow abbreviated empty bodies.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -513,6 +513,29 @@ function fooBarBaz($arg1, &$arg2, $arg3 = [])
 }
 ```
 
+If a function or method contains no statements (such as a no-op implementation or when using
+constructor property promotion), then the body SHOULD be abbreviated as `{}` and placed on the same
+line as the previous symbol, separated by a space.  For example:
+
+```php
+class Point
+{
+    public function __construct(private int $x, private int $y) {}
+    
+    // ...
+}
+```
+
+```php
+class Point
+{
+    public function __construct(
+      public readonly int $x,
+      public readonly int $y,
+    ) {}
+}
+```
+
 ### 4.5 Method and Function Arguments
 
 In the argument list, there MUST NOT be a space before each comma, and there

--- a/spec.md
+++ b/spec.md
@@ -297,6 +297,14 @@ there are no arguments passed to the constructor.
 new Foo();
 ```
 
+If class contains no additional declarations (such as an exception that exists only extend another exception with a new type),
+then the body of the class SHOULD be abbreviated as `{}` and placed on the same line as the previous symbol,
+separated by a space.  For example:
+
+```php
+class MyException extends \RuntimeException {}
+```
+
 ### 4.1 Extends and Implements
 
 The `extends` and `implements` keywords MUST be declared on the same line as


### PR DESCRIPTION
Having worked with CPP a ton in the last year and a half, I feel very strongly that we need this.  The rules otherwise require wasting 2 extra lines of pointlessness that does nothing to aid readability.

I'm making this a SHOULD rather than MUST for BC reasons, but I would be OK with making it a MUST.