### PR TITLE
Added Arrays as Section 12

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1317,7 +1317,7 @@ function allowed()
 }
 ```
 
-## 12. Arrays
+## 11. Arrays
 
 Arrays MUST be declared using the short array syntax.
 

--- a/spec.md
+++ b/spec.md
@@ -1317,6 +1317,45 @@ function allowed()
 }
 ```
 
+## 12. Arrays
+
+Arrays MUST be declared using the short array syntax.
+
+```php
+<?php
+
+$arr = [];
+```
+
+Arrays MUST follow the trailing comma guidelines.
+
+Array declarations MAY be split across multiple lines, where each subsequent line 
+is indented once. When doing so, the first value in the array MUST be on the 
+next line, and there MUST be only one value per line.
+
+When the array declaration is split across multiple lines, the opening bracket 
+MUST be placed on the same line as the equals sign. The closing bracket 
+MUST be placed on the next line after the last value. There MUST NOT be more 
+than one value assignment per line. Value assignments MAY use a single line
+or multiple lines.
+
+```php
+<?php
+
+$arr1 = ['single', 'line', 'declaration'];
+
+$arr2 = [
+    'multi',
+    'line',
+    'declaration',
+    ['values' => 1, 5, 7],
+    [
+        'nested',
+        'array',
+    ],
+];
+```
+
 [PSR-1]: https://www.php-fig.org/psr/psr-1/
 [PSR-12]: https://www.php-fig.org/psr/psr-12/
 [keywords]: http://php.net/manual/en/reserved.keywords.php

--- a/spec.md
+++ b/spec.md
@@ -1394,6 +1394,7 @@ $arr2 = [
         'array',
     ],
 ];
+```
 
 ## 12. Attributes
 


### PR DESCRIPTION
Added section 12 specifying array use. Section 11 is used by https://github.com/php-fig/per-coding-style/pull/26. Applies guidelines like 2.6 Trailing Commas and 4.7 Method and Function Calls to array.

If this PR is preferred over https://github.com/php-fig/per-coding-style/pull/47 then that one can be declined.