### PR TITLE
Update Short Closures spec to remove space after `fn` keyword

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1148,7 +1148,7 @@ $foo->bar(
 Short closures, also known as arrow functions, MUST follow the same guidelines
 and principles as long closures above, with the following additions.
 
-The `fn` keyword MUST be preceded and succeeded by a space.
+The `fn` keyword MUST be preceded by a space, and MUST NOT be succeeded by a space.
 
 The `=>` symbol MUST be preceded and succeeded by a space.
 
@@ -1161,12 +1161,12 @@ The following examples show proper common usage of short closures.
 
 ```php
 
-$func = fn (int $x, int $y): int => $x + $y;
+$func = fn(int $x, int $y): int => $x + $y;
 
-$func = fn (int $x, int $y): int
+$func = fn(int $x, int $y): int
     => $x + $y;
 
-$func = fn (
+$func = fn(
     int $x,
     int $y,
 ): int


### PR DESCRIPTION
Per the accepted [Arrow Functions RFC](https://wiki.php.net/rfc/arrow_functions_v2) and [per its author](https://www.reddit.com/r/PHP/comments/fctb18/comment/fjd9u6a/), short closures were intended to be written without a space after the `fn` keyword. This is also the default formatting enforced by PhpStorm.

PHP-CS-Fixer was an outlier which incorrectly enforced spacing after the `fn` keyword using the same setting as for the `function` keyword. This was a bug and has been corrected with the addition of a separate `closure_fn_spacing` setting (though this setting still defaults to `one` for backwards compatibility - the plan was to [change it to enforce no space](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/b577444c38b61f2fdc32cd0a4685bd595be391b7/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php#L235) in the next major 4.0 version). But the current PER coding style spec may get in the way of this plan.

Since the primary goal of arrow functions is to avoid the verbosity of anonymous functions, requiring a space after the `fn` keyword is a step backwards, and also doesn't align with general usage promoted by PhpStorm as well as the accepted PHP RFC and documentation.

The section on Short Closures was not added until the 17th of July by https://github.com/php-fig/per-coding-style/pull/17, which was after the 1.0.0 spec was approved/released on June 9, so I'm hoping it's not too late to correct it.