### PR TITLE
Clarify `fn` keyword's usage as argument

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1188,7 +1188,7 @@ $foo->bar(
 Short closures, also known as arrow functions, MUST follow the same guidelines
 and principles as long closures above, with the following additions.
 
-The `fn` keyword MUST be preceded by a space, and MUST NOT be succeeded by a space.
+The `fn` keyword MUST NOT be succeeded by a space.
 
 The `=>` symbol MUST be preceded and succeeded by a space.
 
@@ -1211,6 +1211,8 @@ $func = fn(
     int $y,
 ): int
     => $x + $y;
+
+$result = $collection->reduce(fn(int $x, int $y): int => $x + $y, 0);
 ```
 
 ## 8. Anonymous Classes


### PR DESCRIPTION
This PR removes the "preceding space" requirement from the `fn` keyword used in short closures in order to allow using short closures as arguments without needing to include a preceeding space.

```php
// Current spec:
foo( fn(int $x, int $y): int => $x + $y);

// After this PR:
foo(fn(int $x, int $y): int => $x + $y);