### PR TITLE
Update to step away from the working group.

### DIFF
--- a/meta.md
+++ b/meta.md
@@ -189,7 +189,6 @@ specification for a full understanding of its contents.
 ### 6.3. Working Group Members:
 
 * Alexander Makarov
-* Kathryn Reeve
 * Ken Guest
 * Larry Garfield
 * Luke Diggins


### PR DESCRIPTION
This update removes me, Kathryn Reeve, from the working group list.

This is due to time constraints and other factors impeding my ability to continue.

I thank you for the inclusion.