### PR TITLE
Clarify the scope of this PER in the meta document

### DIFF
--- a/meta.md
+++ b/meta.md
@@ -49,11 +49,9 @@ With PSR-12 being the base of this PER, a list of differences is provided below 
 but it should be considered as an independent specification.
 
 This PER will eventually incorporate and replace any stylistic requirements found in PSR-1.
-PER-1 includes a number of non-stylistic requirements that affect runtime behavior, which are
-out of scope for this PER.
-
-If a particular rule is mentioned in both this PER and PSR-1, this PER takes precedence. If not,
-the PSR-1 rule (including errata) still applies.
+PSR-1 includes a number of non-stylistic requirements that affect runtime behavior, which are
+out of scope for this PER. If a particular rule is mentioned in both this PER and PSR-1,
+this PER takes precedence. If not, the PSR-1 rule (including errata) still applies.
 
 This PER will include coding style guidelines related to new functionality added to PHP
 after the publication of PSR-12, as well as clarifications on the text of PSR-12.

--- a/meta.md
+++ b/meta.md
@@ -44,18 +44,23 @@ This PER shares the same goals as PSR-12.
 > of guidelines to be used among all those projects. Thus, the benefit of this guide is
 > not in the rules themselves, but in the sharing of those rules.
 
-This PER is an extension of PSR-12, and therefore also an extension of PSR-1.
+This PER extends, expands and replaces PSR-12, and is therefore also an extension of PSR-1.
 With PSR-12 being the base of this PER, a list of differences is provided below to assist with migration,
 but it should be considered as an independent specification.
 
+It is a long term goal of this PER to incorporate requirements found in PSR-1 that exclusively concern coding style,
+so that all coding style guidelines can eventually be found in one specification.
+However, this PER is not a replacement for PSR-1 and requires adherence to it.
+
 This PER will include coding style guidelines related to new functionality added to PHP
-after the publication of PSR-12. This PER will also include clarifications on the text of
-PSR-12.
+after the publication of PSR-12, as well as clarifications on the text of PSR-12.
+It is a goal of this PER to maintain style consistency between old and new PHP syntax.
+In rare cases, this may require new releases to include coding style guidelines that break backwards compatibility, limited by the non-goals sub-section below.
 
 ### 3.2. Non-Goals
 
-It is not the intention of this PER to add entirely new coding style guidelines. It will
-also not change anything stipulated in PSR-1 and PSR-12.
+It is not the intention of this PER to significantly alter the coding style guidelines specified in PSR-1 and PSR-12.
+It will not change anything stipulated in PSR-1 that concerns technical interoperability or runtime behaviour.
 
 ## 4. Approaches
 

--- a/meta.md
+++ b/meta.md
@@ -48,7 +48,7 @@ This PER extends, expands and replaces PSR-12, and is therefore also an extensio
 With PSR-12 being the base of this PER, a list of differences is provided below to assist with migration,
 but it should be considered as an independent specification.
 
-It is a long term goal of this PER to incorporate requirements found in PSR-1 that concern coding style,
+It is a long term goal of this PER to incorporate coding syle requirements found in PSR-1,
 so that all coding style guidelines can eventually be found in one specification.
 However, this PER is not a replacement for PSR-1 and requires adherence to it and any errata.
 
@@ -61,7 +61,7 @@ the non-goals and versioning sections below.
 
 ### 3.2. Non-Goals
 
-It is not the intention of this PER to substantially alter the coding style guidelines specified in PSR-1 and PSR-12.
+It is not the intention of this PER to substantially or arbitrarily alter coding style guidelines found in PSR-1 and PSR-12.
 It will not change anything stipulated in PSR-1 that concerns technical interoperability or runtime behaviour.
 
 ## 4. Approaches

--- a/meta.md
+++ b/meta.md
@@ -48,9 +48,12 @@ This PER extends, expands and replaces PSR-12, and is therefore also an extensio
 With PSR-12 being the base of this PER, a list of differences is provided below to assist with migration,
 but it should be considered as an independent specification.
 
-It is a long term goal of this PER to incorporate coding syle requirements found in PSR-1,
-so that all coding style guidelines can eventually be found in one specification.
-However, this PER is not a replacement for PSR-1 and requires adherence to it and any errata.
+This PER will eventually incorporate and replace any stylistic requirements found in PSR-1.
+PER-1 includes a number of non-stylistic requirements that affect runtime behavior, which are
+out of scope for this PER.
+
+If a particular rule is mentioned in both this PER and PSR-1, this PER takes precedence. If not,
+the PSR-1 rule (including errata) still applies.
 
 This PER will include coding style guidelines related to new functionality added to PHP
 after the publication of PSR-12, as well as clarifications on the text of PSR-12.

--- a/meta.md
+++ b/meta.md
@@ -48,18 +48,20 @@ This PER extends, expands and replaces PSR-12, and is therefore also an extensio
 With PSR-12 being the base of this PER, a list of differences is provided below to assist with migration,
 but it should be considered as an independent specification.
 
-It is a long term goal of this PER to incorporate requirements found in PSR-1 that exclusively concern coding style,
+It is a long term goal of this PER to incorporate requirements found in PSR-1 that concern coding style,
 so that all coding style guidelines can eventually be found in one specification.
-However, this PER is not a replacement for PSR-1 and requires adherence to it.
+However, this PER is not a replacement for PSR-1 and requires adherence to it and any errata.
 
-This PER will include coding style guidelines related to new functionality added to PHP
+This PER will include coding style guidelines related to new functionality added to PHP 
 after the publication of PSR-12, as well as clarifications on the text of PSR-12.
-It is a goal of this PER to maintain style consistency between old and new PHP syntax.
-In rare cases, this may require new releases to include coding style guidelines that break backwards compatibility, limited by the non-goals sub-section below.
+It is a goal of this PER to maintain style consistency between related old and new PHP syntax,
+such as class constants and constants in enumerations. In rare cases, this may cause new
+releases to include coding style guidelines that break backwards compatibility, limited by
+the non-goals and versioning sections below.
 
 ### 3.2. Non-Goals
 
-It is not the intention of this PER to significantly alter the coding style guidelines specified in PSR-1 and PSR-12.
+It is not the intention of this PER to substantially alter the coding style guidelines specified in PSR-1 and PSR-12.
 It will not change anything stipulated in PSR-1 that concerns technical interoperability or runtime behaviour.
 
 ## 4. Approaches

--- a/meta.md
+++ b/meta.md
@@ -52,7 +52,7 @@ It is a long term goal of this PER to incorporate requirements found in PSR-1 th
 so that all coding style guidelines can eventually be found in one specification.
 However, this PER is not a replacement for PSR-1 and requires adherence to it and any errata.
 
-This PER will include coding style guidelines related to new functionality added to PHP 
+This PER will include coding style guidelines related to new functionality added to PHP
 after the publication of PSR-12, as well as clarifications on the text of PSR-12.
 It is a goal of this PER to maintain style consistency between related old and new PHP syntax,
 such as class constants and constants in enumerations. In rare cases, this may cause new


### PR DESCRIPTION
### What

This pull request:

- Clarifies that this PER obsoletes PSR-12 but extends PSR-1.
- Adds the goal of incorporating PSR-1 requirements related to style.
- Allows for a potential future change to this PER to specify PascalCase class constants.
- Removes vague and meaningless language from non-goals sub-section.

### Why

Excluding 1.0 as a clone of PSR-12, this is effectively the first substantial release of any PER. I feel it is important we're upfront and properly describe the scope of this PER, as was discussed even prior to the 1.0 vote. I do not want it perceived as scope creep to edit this section in a later version.

This change would explicitly allow us to begin adding PSR-1 style rules to this PER immediately in 2.0.x and more clearly advise readers where else to look (ie PSR-1) and not look (ie PSR-12) if they can't yet find a style rule relevant to their code. Currently, the scope section says the spec will only contain additions and clarifications to PSR-12. Arguably you could consider repeating PSR-1 rules as a clarification to PSR-12 but this new wording is unambiguous.

We have previously discussed the potential to recommand PascalCase class constants in this PER. This change is a bit of a roundabout way of saying if we ever do, we'd do that by issuing an errata to PSR-1 optionally allowing PascalCase class constants, then edit this PSR to recommend/require them instead of UPPER_CASE. It also attempts to maintain the non-goal of revisiting PSR-1/PSR-12 decisions without good reason, while allowing us to when such good reason exists. I'm not sure how successful I was in communicating either of these things, so your feedback is most welcome.