### PR TITLE
Remove Woody Gilk from the working group as he is stepping down

### DIFF
--- a/meta.md
+++ b/meta.md
@@ -224,7 +224,6 @@ specification for a full understanding of its contents.
 * Ken Guest
 * Larry Garfield
 * Luke Diggins
-* Woody Gilk
 
 ### 7.4. Special Thanks
 


### PR DESCRIPTION
Woody Gilk asked me to remove him from the working group after he voted in the 2.0.0 readiness vote. Thanks for your time Woody, sad to see you go!