### PR TITLE
Add missing const visibility modifier in enum example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1281,7 +1281,7 @@ enum Suit: string
     case Spades = 'S';
     case Clubs = 'C';
 
-    const Wild = self::Spades;
+    public const Wild = self::Spades;
 }
 ```
 


### PR DESCRIPTION
As per 4.3:

> Visibility MUST be declared on all constants if your project
> PHP minimum version supports constant visibilities
> (PHP 7.1 or later).