### PR TITLE
Modified Keywords code sample contains parse errors

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -676,9 +676,9 @@ namespace Vendor\Package;
 
 abstract class ClassName
 {
-    protected static readonly string $foo;
+    protected static string $foo;
 
-    final protected int $beep;
+    private readonly int $beep;
 
     abstract protected function zim();
 


### PR DESCRIPTION
* The `static` and `readonly` modifiers for properties are, at the time of writing, mutually exclusive, which makes the first property example a parse error.
* `final` properties are not a thing in PHP, which makes the second property example a parse error.

This commit fixes both code examples.

While I can appreciate that the code sample _intends_ to show an example where all possible modifier keywords + type declarations are used, I do not believe that showing this via code which isn't valid PHP to begin with, is helpful.

Introduced in #19.