### PR TITLE
Link to published version of the specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # PER coding style
 
+Published version can be found at https://www.php-fig.org/per/coding-style/.
+
 - [Specification](spec.md)
 - [Meta Document](meta.md)


### PR DESCRIPTION
This helps leading interested parties back to the published version of the living document under development.