### PR TITLE
Do not mention PHP support

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -443,8 +443,7 @@ class Talker
 
 Visibility MUST be declared on all properties.
 
-Visibility MUST be declared on all constants if your project PHP minimum
-version supports constant visibilities (PHP 7.1 or later).
+Visibility MUST be declared on all constants.
 
 The `var` keyword MUST NOT be used to declare a property.
 


### PR DESCRIPTION
This was the only spot in which the PHP support & version was mentioned. Either all statements should have or none.

But it superfluous since the section "[Previous language versions](https://www.php-fig.org/per/coding-style/#previous-language-versions)" already covers it:

> Throughout this document, any instructions MAY be ignored if they do not exist in versions of PHP supported by your project.