### PR TITLE
Only add PHP opening tag when the following rule of thumb are met

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -234,8 +234,6 @@ When using compound namespaces, there MUST NOT be more than two sub-namespaces w
 That is, the following is allowed:
 
 ```php
-<?php
-
 use Vendor\Package\SomeNamespace\{
     SubnamespaceOne\ClassA,
     SubnamespaceOne\ClassB,
@@ -247,8 +245,6 @@ use Vendor\Package\SomeNamespace\{
 And the following would not be allowed:
 
 ```php
-<?php
-
 use Vendor\Package\SomeNamespace\{
     // This has too many namespace segments to be in a group.
     SubnamespaceOne\AnotherNamespace\ClassA,
@@ -504,8 +500,6 @@ A function declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
 ```php
-<?php
-
 function fooBarBaz($arg1, &$arg2, $arg3 = [])
 {
     // function body
@@ -705,8 +699,6 @@ each comma, and there MUST be one space after each comma.
 The following lines show correct calls:
 
 ```php
-<?php
-
 bar();
 $foo->bar($arg1);
 Foo::bar($arg2, $arg3);
@@ -721,8 +713,6 @@ array) does not constitute splitting the argument list itself.
 The following examples show correct argument usage.
 
 ```php
-<?php
-
 $foo->bar(
     $longArgument,
     $longerArgument,
@@ -731,8 +721,6 @@ $foo->bar(
 ```
 
 ```php
-<?php
-
 somefunction($foo, $bar, [
   // ...
 ], $baz);
@@ -789,8 +777,6 @@ spaces, and braces; and that `else` and `elseif` are on the same line as the
 closing brace from the earlier body.
 
 ```php
-<?php
-
 if ($expr1) {
     // if body
 } elseif ($expr2) {
@@ -813,8 +799,6 @@ the line, not a mix of both.
 For example:
 
 ```php
-<?php
-
 if (
     $expr1
     && $expr2
@@ -837,8 +821,6 @@ indented at the same level as the `case` body. There MUST be a comment such as
 `// no break` when fall-through is intentional in a non-empty `case` body.
 
 ```php
-<?php
-
 switch ($expr) {
     case 0:
         echo 'First case, with a break';
@@ -867,8 +849,6 @@ the line, not a mix of both.
 For example:
 
 ```php
-<?php
-
 switch (
     $expr1
     && $expr2
@@ -881,8 +861,6 @@ Similarly, a `match` expression looks like the following. Note the placement
 of parentheses, spaces, and braces.
 
 ```php
-<?php
-
 $returnValue = match ($expr) {
     0 => 'First case',
     1, 2, 3 => multipleCases(),
@@ -896,8 +874,6 @@ A `while` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
 ```php
-<?php
-
 while ($expr) {
     // structure body
 }
@@ -911,8 +887,6 @@ operators between conditions MUST always be at the beginning or at the end of
 the line, not a mix of both.
 
 ```php
-<?php
-
 while (
     $expr1
     && $expr2
@@ -925,8 +899,6 @@ Similarly, a `do while` statement looks like the following. Note the placement
 of parentheses, spaces, and braces.
 
 ```php
-<?php
-
 do {
     // structure body;
 } while ($expr);
@@ -938,8 +910,6 @@ MUST be on the next line. Boolean operators between conditions MUST
 always be at the beginning or at the end of the line, not a mix of both. For example:
 
 ```php
-<?php
-
 do {
     // structure body;
 } while (
@@ -954,8 +924,6 @@ A `for` statement looks like the following. Note the placement of parentheses,
 spaces, and braces.
 
 ```php
-<?php
-
 for ($i = 0; $i < 10; $i++) {
     // for body
 }
@@ -967,8 +935,6 @@ MUST be on the next line. The closing parenthesis and opening brace MUST be
 placed together on their own line with one space between them. For example:
 
 ```php
-<?php
-
 for (
     $i = 0;
     $i < 10;
@@ -984,8 +950,6 @@ A `foreach` statement looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
 ```php
-<?php
-
 foreach ($iterable as $key => $value) {
     // foreach body
 }
@@ -997,8 +961,6 @@ A `try-catch-finally` block looks like the following. Note the placement of
 parentheses, spaces, and braces.
 
 ```php
-<?php
-
 try {
     // try body
 } catch (FirstThrowableType $e) {
@@ -1093,8 +1055,6 @@ A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
 ```php
-<?php
-
 $closureWithArgs = function ($arg1, $arg2) {
     // body
 };
@@ -1121,8 +1081,6 @@ The following are examples of closures with and without argument lists and
 variable lists split across multiple lines.
 
 ```php
-<?php
-
 $longArgs_noVars = function (
     $longArgument,
     $longerArgument,
@@ -1172,8 +1130,6 @@ Note that the formatting rules also apply when the closure is used directly
 in a function or method call as an argument.
 
 ```php
-<?php
-
 $foo->bar(
     $arg1,
     function ($arg2) use ($var1) {
@@ -1221,8 +1177,6 @@ Anonymous Classes MUST follow the same guidelines and principles as closures
 in the above section.
 
 ```php
-<?php
-
 $instance = new class {};
 ```
 
@@ -1234,8 +1188,6 @@ interface.
 If the anonymous class has no arguments, the `()` after `class` MUST be omitted. For example:
 
 ```php
-<?php
-
 // Brace on the same line
 // No arguments
 $instance = new class extends \Foo implements \HandleableInterface {
@@ -1371,8 +1323,6 @@ function allowed()
 Arrays MUST be declared using the short array syntax.
 
 ```php
-<?php
-
 $arr = [];
 ```
 
@@ -1391,8 +1341,6 @@ or multiple lines.
 The following example shows correct array usage:
 
 ```php
-<?php
-
 $arr1 = ['single', 'line', 'declaration'];
 
 $arr2 = [


### PR DESCRIPTION
While I like the consistency of having opening tags everywhere (as in #74), I can see it being "too much", especially for one liners.

What do you think of the following rule of thumb proposal?

Add PHP opening tags when all requirements are met:

- Tne [mandatory class namespace](https://www.php-fig.org/psr/psr-1/#3-namespace-and-class-names) is defined or no class or interface respectively is defined
- All necessary classes & functions are imported
- All necessary variables & constants are defined
- All necessary structures are visible or hinted at with a comment
- All statements and/or structures are related to each other
- Or the PHP opening tag is essential to the code example

Do not add PHP opening tags when:

- Only one or many unrelated statements are shown
- Only one or many unrelated functions are shown
- Only one or many unrelated methods are shown
- Only one or many unrelated classes or interfaces respectively are shown
- Only one or many unrelated other structures, such as an if-clause or match expression, are shown