### PR TITLE
Add missing space in example for anonymous class declaration

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1242,7 +1242,7 @@ $instance = new class extends \Foo implements \HandleableInterface {
 
 // Brace on the next line
 // Constructor arguments
-$instance = new class($a) extends \Foo implements
+$instance = new class ($a) extends \Foo implements
     \ArrayAccess,
     \Countable,
     \Serializable


### PR DESCRIPTION
According to the specification:

> Anonymous Classes MUST follow the same guidelines and principles as closures in the above section.

Therefore a space must be between the class keyword and the opening parenthesis, as with closures.