### PR TITLE
Add ternary operator on multi-line

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1068,18 +1068,21 @@ $variable = $foo ?: 'bar';
 
 ### 6.4. Operator's placement
 
-When a statement that includes an operator must be split into multiple lines,
-the operator SHOULD be placed at the beginning of the new line.
+A statement that includes an operator MAY be split across multiple lines, where
+each subsequent line is indented once. When doing so, the operator MUST be
+placed at the beginning of the new line; ternaries MUST occupy 3 lines, never 2.
+
+For example:
 
 ```php
 <?php
 
-$variable1 = $possibleNullableExpr
-    ?? 'fallback';
-
-$variable2 = $ternaryOperatorExpr
+$variable1 = $ternaryOperatorExpr
     ? 'fizz'
     : 'buzz';
+
+$variable2 = $possibleNullableExpr
+    ?? 'fallback';
 
 $variable3 = $elvisExpr
     ?: 'qix';

--- a/spec.md
+++ b/spec.md
@@ -1057,10 +1057,6 @@ and `:` characters:
 
 ```php
 $variable = $foo ? 'foo' : 'bar';
-
-$variableMultiLine = $foo
-    ? 'foo'
-    : 'bar';
 ```
 
 When the middle operand of the conditional operator is omitted, the operator
@@ -1068,6 +1064,25 @@ MUST follow the same style rules as other binary [comparison][] operators:
 
 ```php
 $variable = $foo ?: 'bar';
+```
+
+### 6.4. Operator's placement
+
+When a statement that includes an operator must be split into multiple lines,
+the operator SHOULD be placed at the beginning of the new line.
+
+```php
+<?php
+
+$variable1 = $possibleNullableExpr
+    ?? 'fallback';
+
+$variable2 = $ternaryOperatorExpr
+    ? 'fizz'
+    : 'buzz';
+
+$variable3 = $elvisExpr
+    ?: 'qix';
 ```
 
 ## 7. Closures

--- a/spec.md
+++ b/spec.md
@@ -1057,6 +1057,10 @@ and `:` characters:
 
 ```php
 $variable = $foo ? 'foo' : 'bar';
+
+$variableMultiLine = $foo
+    ? 'foo'
+    : 'bar';
 ```
 
 When the middle operand of the conditional operator is omitted, the operator


### PR DESCRIPTION
## 📚 Description

Some people write ternary operators as follows:

```php
$foo = true ?
    'foo' :
    'bar';
```

In the previous snippet is kind of easy, but when instead of `'foo'`, it is a long line calling method, etc, it becomes complex.

My proposal is to add the following rule into the PER file to avoid people doing the previous snippet, making the code easier to track when ternary operators are used to improve the legibility; eg:
```php
$foo = true
    ? 'foo'
    : 'bar';
```