### PR TITLE
Recommend omitting wrapping parenthesis when immediately calling a method on a new instance

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -308,6 +308,19 @@ separated by a space. For example:
 class MyException extends \RuntimeException {}
 ```
 
+When calling a method immeditely after instantiating a new class, the instantiation SHOULD NOT be wrapped in 
+parenthesis. For example:
+
+```php
+$methodResult = new Foo()->someMethod();
+```
+
+And the following SHOULD be avoided:
+
+```php
+$methodResult = (new Foo())->someMethod();
+```
+
 ### 4.1 Extends and Implements
 
 The `extends` and `implements` keywords MUST be declared on the same line as

--- a/spec.md
+++ b/spec.md
@@ -308,17 +308,21 @@ separated by a space. For example:
 class MyException extends \RuntimeException {}
 ```
 
-When calling a method immeditely after instantiating a new class, the instantiation SHOULD NOT be wrapped in 
+When accessing a class member immeditely after instantiating a new class, the instantiation SHOULD NOT be wrapped in 
 parenthesis. For example:
 
 ```php
-$methodResult = new Foo()->someMethod();
+new Foo()->someMethod();
+new Foo()->someStaticMethod();
+new Foo()->someProperty;
+new Foo()::someStaticProperty;
+new Foo()::SOME_CONSTANT;
 ```
 
 And the following SHOULD be avoided:
 
 ```php
-$methodResult = (new Foo())->someMethod();
+(new Foo())->someMethod();
 ```
 
 ### 4.1 Extends and Implements


### PR DESCRIPTION
The wording for this was proving tricky so I've included a counter example to make it more obvious what we're recommending be omitted.

Relates to #89 