### PR TITLE
Undo capitalization of `// no break` to prevent tooling issues

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1092,7 +1092,7 @@ A `switch` structure looks like the following. Note the placement of
 parentheses, spaces, and braces. The `case` statement MUST be indented once
 from `switch`, and the `break` keyword (or other terminating keywords) MUST be
 indented at the same level as the `case` body. There MUST be a comment such as
-`// No break` when fall-through is intentional in a non-empty `case` body.
+`// no break` when fall-through is intentional in a non-empty `case` body.
 
 ```php
 <?php
@@ -1103,7 +1103,7 @@ switch ($expr) {
         break;
     case 1:
         echo 'Second case, which falls through';
-        // No break
+        // no break
     case 2:
     case 3:
     case 4:


### PR DESCRIPTION
In [PR 79](https://github.com/php-fig/per-coding-style/pull/79) all comments where either replaced with ellipsis or capitalized. The `// no break` comment however is used literally in various tools and capitalizing this might lead to tooling regressions.

For reference, literal `// no break` seems to be a de-facto standard, even if it is not explicitly phrased as such: 
- https://youtrack.jetbrains.com/issue/WI-32123/Usage-of-PSR-2-comment-suggestion-on-no-break-switch-cases
- https://cs.symfony.com/doc/rules/control_structure/no_break_comment.html && https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.75.0/src/Fixer/ControlStructure/NoBreakCommentFixer.php#L116
- https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#clever-code


