### PR TITLE
Clarify what visibility must be declared.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -519,7 +519,7 @@ class Talker
 
 ### 4.3 Properties and Constants
 
-Visibility MUST be declared on all properties.
+Visibility MUST be declared on all properties.  If set-visibility is specified, then the general visibility MAY be omitted.
 
 Visibility MUST be declared on all constants.
 


### PR DESCRIPTION
Resolves #114.

This is an obvious change so I'm going to go ahead and commit it.  The PR is just for historical reference and transparency.