### PR TITLE
Spec section 4: static properties need a `$`

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -376,7 +376,7 @@ parentheses. For example:
 new Foo()->someMethod();
 new Foo()->someStaticMethod();
 new Foo()->someProperty;
-new Foo()::someStaticProperty;
+new Foo()::$someStaticProperty;
 new Foo()::SOME_CONSTANT;
 ```
 


### PR DESCRIPTION
Fix example from `new Foo()::someStaticProperty;` to `new Foo()::$someStaticProperty;`