### PR TITLE
Spec section 4: static methods should be called statically

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -374,7 +374,7 @@ parentheses. For example:
 
 ```php
 new Foo()->someMethod();
-new Foo()->someStaticMethod();
+new Foo()::someStaticMethod();
 new Foo()->someProperty;
 new Foo()::someStaticProperty;
 new Foo()::SOME_CONSTANT;


### PR DESCRIPTION
Technically they work fine when called non-statically, but doing so is generally discouraged