### PR TITLE
The PER shouldn't refer to itself as a PSR

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -224,7 +224,7 @@ $result = match ($a) {
 
 ### 2.7 Naming
 
-This STANDARD RECOMMENDS following the [php-src coding standards](https://github.com/php/php-src/blob/master/CODING_STANDARDS.md#user-functionsmethods-naming-conventions) with regard to abbreviations and acronyms.
+This Standard RECOMMENDS following the [php-src coding standards](https://github.com/php/php-src/blob/master/CODING_STANDARDS.md#user-functionsmethods-naming-conventions) with regard to abbreviations and acronyms.
 
 Specifically:
 


### PR DESCRIPTION
There are some occurrences in PER-CS where it refers to itself as "This PSR". These occurrences should be changed to "this standard"