### PR TITLE
Add an example for closure with an empty body

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1399,10 +1399,17 @@ $closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool
 };
 ```
 
-If a closure contains no statements, it MUST use the "arrow function" style syntax:
+If a closure contains no statements, then the body MUST be abbreviated as `{}` and placed on the same
+line as the previous symbol, separated by a space:
 
 ```php
-fn() => null;
+$noOpFunction = function () {};
+```
+
+If possible, empty-body closures SHOULD be replaced with arrow functions:
+
+```php
+$noOpFunction = fn() => null;
 ```
 
 Argument lists and variable lists MAY be split across multiple lines, where


### PR DESCRIPTION
@keradus suggested clarifying the situation with closures that have an empty body: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9329#discussion_r2666828667

I agree with him. I think the `Closures` section lacks an example with an empty body. It seems logical to add an example similar to the one in the `Classes, Properties, and Methods` section:

https://github.com/php-fig/per-coding-style/blob/c83ab639793d8b5c8c7516e54cdf0df18c4d592e/spec.md?plain=1#L592-L603

What do you think about this?