### PR TITLE
Add Section 6.1 to the PER-CS 1.0 to 2.0 migration guide

### DIFF
--- a/migration-2.0.md
+++ b/migration-2.0.md
@@ -138,6 +138,15 @@ $returnValue = match ($expr) {
 };
 ```
 
+## [Section 6.1 - Unary operators](https://www.php-fig.org/per/coding-style/#61-unary-operators)
+
+The type casting operators rule was updated to also require a single space between the cast and the variable it operates on.
+
+```php
+<?php
+$intValue = (int) $input;
+```
+
 ## [Section 7.1 - Short Closures](https://www.php-fig.org/per/coding-style/#71-short-closures)
 
 A new subsection about Short Closures, as per the link above. Example as follows:


### PR DESCRIPTION
PER-CS 2.0 introduces a new normative rule in [Section 6.1](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#61-unary-operators):

> Type casting operators MUST NOT have any space within the parentheses and MUST be separated from the variable they are operating on by exactly one space.

The clause "and MUST be separated from the variable they are operating on by exactly one space" was added by #40 and is not present in [Section 6.1 in 1.0](https://github.com/php-fig/per-coding-style/blob/1.0.0/spec.md#61-unary-operators). I'm new to this repository, so I might be missing something, but this change is not documented in the 2.0 migration guide, and I believe it should be.

This PR adds a Section 6.1 entry to `migration-2.0.md`.

The new Section 6.1 heading uses the same unversioned `php-fig.org` URL as the existing entries. This URL currently points to PER-CS 3.0. I'm not sure if this is correct. I opened https://github.com/php-fig/per-coding-style/issues/138 to discuss it.