### PR TITLE
lapsus: s/intersection/union/ with null

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -179,7 +179,7 @@ function veryComplex(
 
 If one of the ORed conditions is `null`, it MUST be the last item in the list.
 
-An intersection of a single simple type with `null` SHOULD be abbreviated using the `?` alternate syntax: `?T`.
+A union of a single simple type with `null` SHOULD be abbreviated using the `?` alternate syntax: `?T`.
 
 ### 2.6 Trailing commas
 


### PR DESCRIPTION
An intersection of a type with `null` is semantically either `null` or `never` (depending on whether the type is nullable). But it is not allowed by PHP anyway.