### PR TITLE
Add Section 4 to the PER-CS 1.0 to 2.0 migration guide

### DIFF
--- a/migration-2.0.md
+++ b/migration-2.0.md
@@ -40,6 +40,15 @@ function beep(
 }
 ```
 
+## [Section 4 - Classes, Properties, and Methods](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#4-classes-properties-and-methods)
+
+A new rule was added stating that if a class contains no additional declarations, then the body of the class SHOULD be abbreviated as `{}` and placed on the same line as the previous symbol, separated by a space.
+
+```php
+<?php
+class MyException extends \RuntimeException {}
+```
+
 ## [Section 4.4 - Methods and Functions](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#44-methods-and-functions)
 
 If a function or method contains no statements or comments (such as an empty


### PR DESCRIPTION
PER-CS 2.0 introduces a new rule in [Section 4](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#4-classes-properties-and-methods):

> If class contains no additional declarations (such as an exception that exists only to extend another exception with a new type), then the body of the class SHOULD be abbreviated as `{}` and placed on the same line as the previous symbol, separated by a space.

This rule was added by #44 and is not present in [Section 4 in 1.0](https://github.com/php-fig/per-coding-style/blob/1.0.0/spec.md#4-classes-properties-and-methods).

This PR adds a Section 4 entry to `migration-2.0.md`.

As with #139, the new Section 4 heading uses the unversioned `php-fig.org` URL to match the existing entries. See #138 for the related discussion about whether this URL should be versioned.