### PR TITLE
Add Section 8 to the PER-CS 1.0 to 2.0 migration guide

### DIFF
--- a/migration-2.0.md
+++ b/migration-2.0.md
@@ -167,6 +167,19 @@ $func = fn(
 $result = $collection->reduce(fn(int $x, int $y): int => $x + $y, 0);
 ```
 
+## [Section 8 - Anonymous Classes](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#8-anonymous-classes)
+
+A new rule was added stating that if an anonymous class has no arguments, the `()` after `class` MUST be omitted.
+
+```php
+<?php
+
+// No arguments: `()` must be omitted.
+$instance = new class extends \Foo {
+    // Class content
+};
+```
+
 ## [Section 9 - Enumerations](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#9-enumerations)
 
 Enums are now covered, as per the link above. Please see below for examples.


### PR DESCRIPTION
PER-CS 2.0 introduces a new rule in [Section 8](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#8-anonymous-classes):

> If the anonymous class has no arguments, the `()` after `class` MUST be omitted.

This rule was added by #37 and is not present in [Section 8 in 1.0](https://github.com/php-fig/per-coding-style/blob/1.0.0/spec.md#8-anonymous-classes).

This PR adds a Section 8 entry to `migration-2.0.md`.

As with #139, the new Section 8 heading uses the unversioned `php-fig.org` URL to match the existing entries. See #138 for the related discussion about whether this URL should be versioned.