### PR TITLE
Expand Section 4.3 entry in the PER-CS 2.0 to 3.0 migration guide

### DIFF
--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -73,6 +73,11 @@ class Foo
 }
 ```
 
+Two rules previously stated only for properties were extended to also apply to constants:
+
+* There MUST NOT be more than one property or constant declared per statement.
+* Property or constant names MUST NOT be prefixed with a single underscore.
+
 ## [Section 4.6 - Modifier Keywords](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#46-modifier-keywords)
 
 At least one of `readonly`, `get`-visibility, and `set`-visibility must be specified.  If at least one is specified, the others may be omitted.


### PR DESCRIPTION
PER-CS 3.0 extended two rules from [Section 4.3](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#43-properties-and-constants) that previously applied only to properties, so they now also apply to constants. Both were introduced by #72:

- The "no more than one declared per statement" rule now covers both properties and constants. Compare [section 4.3 in 2.0](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#43-properties-and-constants) (*"There MUST NOT be more than one property declared per statement."*) with [section 4.3 in 3.0](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#43-properties-and-constants) (*"There MUST NOT be more than one property or constant declared per statement."*).
- The "no single underscore prefix" rule now covers both property and constant names. Compare 2.0 (*"Property names MUST NOT be prefixed with a single underscore..."*) with 3.0 (*"Property or constant names MUST NOT be prefixed with a single underscore..."*).

Neither is documented in the migration guide. This PR adds them as a bulleted list to the existing Section 4.3 entry.