### PR TITLE
Add Section 4.10 entry to the PER-CS 2.0 to 3.0 migration guide

### DIFF
--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -129,6 +129,30 @@ class Example
 }
 ```
 
+## [Section 4.10 - Interface and abstract properties](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#410-interface-and-abstract-properties)
+
+This is a new section about interface and abstract properties, as per the link above. Examples follow:
+
+```php
+abstract class Example {
+    abstract public string $name {
+        get => ucfirst($this->name);
+        set;
+    }
+}
+```
+
+```php
+interface Example
+{
+    public string $readable { get; }
+
+    public string $writeable { set; }
+
+    public string $both { get; set; }
+}
+```
+
 ## [Section 5.2 - Switch, Case, and Match](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#52-switch-case-match)
 
 When breaking a series of boolean operators across multiple lines, the operator MUST be at the beginning of each line, not the end of each line.


### PR DESCRIPTION
PER-CS 3.0 added a new [Section 4.10 — Interface and abstract properties](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#410-interface-and-abstract-properties). The section did not exist in [2.0](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md). It was introduced by #108.

The migration guide had no entry for Section 4.10. This PR adds one, following the format used for other new sections in the migration guide, like sections 10, 11, 12 in `migration-2.0.md`: a brief introduction pointing readers at the spec, followed by example code blocks.

The Section 4.10 heading uses the same unversioned `php-fig.org` URL as the existing entries. See #138 for the related discussion about whether this URL should be versioned.

