### PR TITLE
Rewrite Section 4.6 entry in the PER-CS 2.0 to 3.0 migration guide

### DIFF
--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -75,7 +75,9 @@ class Foo
 
 ## [Section 4.6 - Modifier Keywords](https://www.php-fig.org/per/coding-style/#46-modifier-keywords)
 
-At least one of `readonly`, `get`-visibility, and `set`-visibility must be specified.  If at least one is specified, the others may be omitted.
+The set-visibility modifier (`public(set)`, `protected(set)`, `private(set)`) was added to the modifier ordering, between the general visibility and the `static` modifier.
+
+All modifier keywords MUST be all lower-case. The `public` keyword MAY be omitted when using a set-visibility on a public-read property.
 
 ```php
 class Foo
@@ -83,9 +85,9 @@ class Foo
     // These are all acceptable.
     public private(set) string $one;
     private(set) string $two;
-    readonly string $three;
 
     // These are not.
+    PUBLIC PROTECTED(set) string $three;
     private(set) public string $four;
 }
 ```


### PR DESCRIPTION
The current Section 4.6 entry in `migration-3.0.md` says:

> At least one of `readonly`, `get`-visibility, and `set`-visibility must be specified. If at least one is specified, the others may be omitted.

As far as I can see, this sentence does not match what actually changed in 3.0, and the related `readonly string $three;` is not related to the changes introduced in 3.0 and is incorrect per the spec, as it is missing the visibility modifier.

What I believe did actually change in [Section 4.6 in 3.0](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#46-modifier-keywords), all introduced by #99:

- The set-visibility modifier (`public(set)`, `protected(set)`, `private(set)`) was added to the modifier ordering, between general visibility and `static`. Compare the [2.0 modifier order](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#46-modifier-keywords) (no set-visibility) with the [3.0 modifier order](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#46-modifier-keywords).
- All modifier keywords MUST be all lower-case. New in 3.0; the 2.0 spec only required keywords to be on a single line separated by spaces.
- The `public` keyword MAY be omitted when using a set-visibility on a public-read property. New in 3.0 (refined within #99 by commit [`5724087`](https://github.com/php-fig/per-coding-style/commit/5724087)).

This PR proposes rewriting the entry to cover those three rules and updating the example accordingly:

- The `readonly string $three;` line is removed, since (as discussed above) it appears to be inconsistent with Section 4.3.
- A new counter-example `PUBLIC PROTECTED(set) string $three;` is added to illustrate the new lower-case requirement.

Happy to revise or drop any of this if I'm misreading the spec.