### PR TITLE
Expand Section 2.7 entry in the PER-CS 2.0 to 3.0 migration guide

### DIFF
--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -51,7 +51,7 @@ function veryComplex(
 
 ## [Section 2.7 - Naming](https://www.php-fig.org/per/coding-style/#27-naming)
 
-PER-CS now recommends following the same naming conventions as PHP Internals for abbreviations and acronyms.  Specifically, only uppercase the first character of the acronym: `XmlFormatter`, not `XMLFormatter`.
+PER-CS now recommends following the same naming conventions as PHP Internals for abbreviations and acronyms. Abbreviations, acronyms, and initialisms SHOULD be avoided wherever possible, unless they are much more widely used than the long form (e.g. `HTTP` or `URL`). When they are used, only the first character should be uppercased: `XmlFormatter`, not `XMLFormatter`.
 
 ## [Section 3 - Declare Statements, Namespace, and Import Statements](https://www.php-fig.org/per/coding-style/#3-declare-statements-namespace-and-import-statements)
 


### PR DESCRIPTION
PER-CS 3.0 introduced a new [Section 2.7](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#27-naming). It adopts the [php-src naming conventions](https://github.com/php/php-src/blob/master/CODING_STANDARDS.md#user-functionsmethods-naming-conventions) for abbreviations and acronyms, quoting them directly:

> Abbreviations and acronyms as well as initialisms SHOULD be avoided wherever possible, unless they are much more widely used than the long form (e.g. HTTP or URL). Abbreviations, acronyms, and initialisms SHOULD be treated like regular words, thus they SHOULD be written with an uppercase first character, followed by lowercase characters.

In the spec, the SHOULD-avoid recommendation is the lead rule and the capitalization rule (`XmlFormatter` not `XMLFormatter`) is the dependent follow-on. The migration guide's existing Section 2.7 entry covered only the capitalization rule and omitted the SHOULD-avoid recommendation entirely.

This section was introduced by #102. This PR rewrites the entry so it leads with the SHOULD-avoid recommendation and keeps the capitalization rule as the follow-on.