### PR TITLE
Expand Section 6.4 entry in the PER-CS 2.0 to 3.0 migration guide

### DIFF
--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -137,7 +137,7 @@ When breaking a series of boolean operators across multiple lines, the operator 
 
 ## [Section 6.4 - Operator placement](https://www.php-fig.org/per/coding-style/#64-operator-placement)
 
-When breaking a series of chained operations across multiple lines, the operator MUST be at the beginning of each line, not the end of each line, and all lines but the first MUST be indented.  Examples include `??` and ternary conditionals.
+When breaking a series of chained operations across multiple lines, the operator MUST be at the beginning of each line, not the end of each line, and all lines but the first MUST be indented.  Examples include `??` and ternary conditionals. Ternaries MUST occupy 3 lines, never 2.
 
 ```php
 <?php


### PR DESCRIPTION
[Section 6.4](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#64-operators-placement) is new in 3.0. It states:

> A statement that includes an operator MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the operator MUST be placed at the beginning of the new line; ternaries MUST occupy 3 lines, never 2.

The migration guide already has a Section 6.4 entry covering the general operator-at-start rule, but it does not state the ternary-specific 3-lines constraint.

Section 6.4 was introduced by #93. This PR appends the missing ternary constraint to the existing entry.