### PR TITLE
Expand Section 2.5 entry in the PER-CS 2.0 to 3.0 migration guide

### DIFF
--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -24,7 +24,10 @@ is the canonical source for the PER-CS formatting expectations.
 Formatting conventions are now provided for compound types (those that include union or intersection type declarations).
 
 * The `|` and `&` symbols and parentheses MUST NOT have leading or trailing spaces.
-* If a type declaration is long enough to split to multiple lines, each ANDed block must be on one line, and each ORed block on its own line.
+* If a type declaration is long enough to split to multiple lines:
+  * If the type is only unions or only intersections, each line holds a single type.
+  * If it mixes both, each line holds one union segment, with that segment's intersected types kept together.
+  * The symbol on which it is split MUST be at the start of each line.
 * If one of the types listed is `null`, it must come last.
 * Favor `?` over `|null` in cases where both work.
 * A multi-catch statement must follow the same rules.  (See section 5.6 as well.)


### PR DESCRIPTION
[Section 2.5](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#25-keywords-and-types) in 3.0 defines how to split a compound type across multiple lines:

> * If the type contains only intersections or only unions, then each line MUST have a single type.
> * If the type contains both intersections and unions, then each line MUST have a single union segment. All intersections in a segment MUST be on the same line.
> * The symbol on which the compound type is split MUST be at the start of each line.

The migration guide's existing Section 2.5 entry compressed these into a single bullet that omitted the symbol at start requirement and was inaccurate for pure intersections.

These rules, along with the rest of the compound-type formatting conventions, were introduced by #45. This PR rewrites the splitting guidance into three bullets that match the spec, in the same order.