### PR TITLE
Section 9: Apply the private instead of protected rule to enum constants

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1597,10 +1597,10 @@ $example = new
 
 ## 9. Enumerations
 
-Enumerations (enums) MUST follow the same guidelines as classes, except where otherwise noted below.
+Enumerations (enums) MUST follow the same guidelines as classes (including the guidelines for class methods and
+constants), except where otherwise noted below.
 
-Methods in enums MUST follow the same guidelines as methods in classes. Non-public methods MUST use `private`
-instead of `protected`, as enums do not support inheritance.
+Non-public methods and constants MUST use `private` instead of `protected`, as enums do not support inheritance.
 
 When using a backed enum, there MUST NOT be a space between the enum name and colon, and there MUST be exactly one
 space between the colon and the backing type. This is consistent with the style for return types.


### PR DESCRIPTION
Section 9 required non-public enum methods to use `private` instead of `protected` but said nothing about constants. The rationale that enums do not support inheritance, so `protected` is meaningless, applies equally to constants, so the omission was likely an oversight (see issue #150).

While broadening the rule, I also dropped the "Methods in enums MUST follow the same guidelines as methods in classes" sentence. I first considered just adding constants to it, but that sentence was already redundant with the opening line, which states that enums follow the guidelines for classes. Spelling out "methods and constants" would only have made the duplication more obvious. So instead I collapsed it into the opening line, which now mentions class methods and constants explicitly to preserve that emphasis. Happy to drop this second change if there is no consensus that this is an improvement to make this PR focused only on what was discussed in #150.

Fixes #150