### PR TITLE
Point migration guide links to the target version on GitHub

### DIFF
--- a/migration-2.0.md
+++ b/migration-2.0.md
@@ -17,10 +17,10 @@ and focuses on the changes on a section-by-section basis as its focus is to be m
 This document intends to provide a summary of these changes that can
 then be used to drive action lists for toolset producers to support PER-CS v2.0.
 
-This document is non-normative.  The published [2.0 PER-CS](https://www.php-fig.org/per/coding-style/) specification 
+This document is non-normative.  The published [2.0 PER-CS](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md) specification 
 is the canonical source for the PER-CS formatting expectations.
 
-## [Section 2.6 - Trailing Commas](https://www.php-fig.org/per/coding-style/#26-trailing-commas)
+## [Section 2.6 - Trailing Commas](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#26-trailing-commas)
 
 Numerous constructs now allow a sequence of values to have an optional trailing
 comma:
@@ -40,7 +40,7 @@ function beep(
 }
 ```
 
-## [Section 4.4 - Methods and Functions](https://www.php-fig.org/per/coding-style/#44-methods-and-functions)
+## [Section 4.4 - Methods and Functions](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#44-methods-and-functions)
 
 If a function or method contains no statements or comments (such as an empty
 no-op implementation or when using constructor property promotion), then the
@@ -56,7 +56,7 @@ class SubClass extends BaseClass
 }
 ```
 
-## [Section 4.6 - Modifier Keywords](https://www.php-fig.org/per/coding-style/#46-modifier-keywords)
+## [Section 4.6 - Modifier Keywords](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#46-modifier-keywords)
 
 Modifier keywords are keywords that alter how PHP handles classes,
 properties and methods.
@@ -87,7 +87,7 @@ abstract class ClassName
 Furthermore, all keywords must be on a single line and MUST be separated
 by a single space.
 
-## [Section 4.7 - Method and Function Calls](https://www.php-fig.org/per/coding-style/#47-method-and-function-calls)
+## [Section 4.7 - Method and Function Calls](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#47-method-and-function-calls)
 
 If using named arguments, there MUST NOT be a space between the argument name and the colon, 
 and there MUST be a single space between the colon and the argument value.
@@ -107,7 +107,7 @@ $someInstance
     ->run();
 ```
 
-## [Section 4.8 - Function Callable References](https://www.php-fig.org/per/coding-style/#48-function-callable-references)
+## [Section 4.8 - Function Callable References](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#48-function-callable-references)
 
 Function callable references - there must not be whitespace surrounding the '...' operator ()
 
@@ -116,7 +116,7 @@ Function callable references - there must not be whitespace surrounding the '...
 $callable = $item->doSomething(...);
 ```
 
-## [Section 5.2 - Switch, Case, Match](https://www.php-fig.org/per/coding-style/#52-switch-case-match)
+## [Section 5.2 - Switch, Case, Match](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#52-switch-case-match)
 
 The match keyword is now covered.
 
@@ -138,7 +138,7 @@ $returnValue = match ($expr) {
 };
 ```
 
-## [Section 6.1 - Unary operators](https://www.php-fig.org/per/coding-style/#61-unary-operators)
+## [Section 6.1 - Unary operators](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#61-unary-operators)
 
 The type casting operators rule was updated to also require a single space between the cast and the variable it operates on.
 
@@ -147,7 +147,7 @@ The type casting operators rule was updated to also require a single space betwe
 $intValue = (int) $input;
 ```
 
-## [Section 7.1 - Short Closures](https://www.php-fig.org/per/coding-style/#71-short-closures)
+## [Section 7.1 - Short Closures](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#71-short-closures)
 
 A new subsection about Short Closures, as per the link above. Example as follows:
 
@@ -167,7 +167,7 @@ $func = fn(
 $result = $collection->reduce(fn(int $x, int $y): int => $x + $y, 0);
 ```
 
-## [Section 9 - Enumerations](https://www.php-fig.org/per/coding-style/#9-enumerations)
+## [Section 9 - Enumerations](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#9-enumerations)
 
 Enums are now covered, as per the link above. Please see below for examples.
 
@@ -194,7 +194,7 @@ enum Size
 }
 ```
 
-## [Section 10 - Heredoc and Nowdoc](https://www.php-fig.org/per/coding-style/#10-heredoc-and-nowdoc)
+## [Section 10 - Heredoc and Nowdoc](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#10-heredoc-and-nowdoc)
 
 This is a new section about Heredoc and Nowdoc notation as per the link above.
 Example follows:
@@ -233,7 +233,7 @@ function allowed()
 }
 ```
 
-## [Section 11 - Arrays](https://www.php-fig.org/per/coding-style/#11-arrays)
+## [Section 11 - Arrays](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#11-arrays)
 
 This is a new section about arrays, as per the link above.
 Example as follows:
@@ -253,7 +253,7 @@ $arr2 = [
 ];
 ```
 
-## [Section 12 - Attributes](https://www.php-fig.org/per/coding-style/#12-attributes)
+## [Section 12 - Attributes](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#12-attributes)
 
 This is a new section, as per the above link.
 The following is an example of valid usage.

--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -16,10 +16,10 @@ and focuses on the changes on a section-by-section basis as its focus is to be m
 This document intends to provide a summary of these changes that can
 then be used to drive action lists for toolset producers to support PER-CS v3.0.
 
-This document is non-normative.  The published [3.0 PER-CS](https://www.php-fig.org/per/coding-style/) specification 
+This document is non-normative.  The published [3.0 PER-CS](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md) specification 
 is the canonical source for the PER-CS formatting expectations.
 
-## [Section 2.5 - Keywords and Types](https://www.php-fig.org/per/coding-style/#25-keywords-and-types)
+## [Section 2.5 - Keywords and Types](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#25-keywords-and-types)
 
 Formatting conventions are now provided for compound types (those that include union or intersection type declarations).
 
@@ -49,19 +49,19 @@ function veryComplex(
 }
 ```
 
-## [Section 2.7 - Naming](https://www.php-fig.org/per/coding-style/#27-naming)
+## [Section 2.7 - Naming](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#27-naming)
 
 PER-CS now recommends following the same naming conventions as PHP Internals for abbreviations and acronyms.  Specifically, only uppercase the first character of the acronym: `XmlFormatter`, not `XMLFormatter`.
 
-## [Section 3 - Declare Statements, Namespace, and Import Statements](https://www.php-fig.org/per/coding-style/#3-declare-statements-namespace-and-import-statements)
+## [Section 3 - Declare Statements, Namespace, and Import Statements](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#3-declare-statements-namespace-and-import-statements)
 
 The `<?php` tag must always be all-lowercase.
 
-## [Section 4 - Classes, Properties, and Methods](https://www.php-fig.org/per/coding-style/#4-classes-properties-and-methods)
+## [Section 4 - Classes, Properties, and Methods](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#4-classes-properties-and-methods)
 
 If using PHP 8.4 or later, parentheses should be omitted around a `new` declaration.
 
-## [Section 4.3 - Properties and Constants](https://www.php-fig.org/per/coding-style/#43-properties-and-constants)
+## [Section 4.3 - Properties and Constants](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#43-properties-and-constants)
 
 If a property has a `set`-visibility defined, the `get` visibility may be omitted.
 
@@ -73,7 +73,7 @@ class Foo
 }
 ```
 
-## [Section 4.6 - Modifier Keywords](https://www.php-fig.org/per/coding-style/#46-modifier-keywords)
+## [Section 4.6 - Modifier Keywords](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#46-modifier-keywords)
 
 At least one of `readonly`, `get`-visibility, and `set`-visibility must be specified.  If at least one is specified, the others may be omitted.
 
@@ -90,11 +90,11 @@ class Foo
 }
 ```
 
-## [Section 4.7 - Methods and Function Calls](https://www.php-fig.org/per/coding-style/#47-method-and-function-calls)
+## [Section 4.7 - Methods and Function Calls](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#47-method-and-function-calls)
 
 The `exit()` and `die()` functions should always be called with parentheses, even though PHP technically permits them without.
 
-## [Section 4.9 - Property hooks](https://www.php-fig.org/per/coding-style/#49-property-hooks)
+## [Section 4.9 - Property hooks](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#49-property-hooks)
 
 Formatting guidelines for property hooks are now included.
 
@@ -129,13 +129,13 @@ class Example
 }
 ```
 
-## [Section 5.2 - Switch, Case, and Match](https://www.php-fig.org/per/coding-style/#52-switch-case-match)
+## [Section 5.2 - Switch, Case, and Match](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#52-switch-case-match)
 
 When breaking a series of boolean operators across multiple lines, the operator MUST be at the beginning of each line, not the end of each line.
 
 (This applies to `switch`, `match`, `while`, `do while`, and any other expression.)
 
-## [Section 6.4 - Operator placement](https://www.php-fig.org/per/coding-style/#64-operator-placement)
+## [Section 6.4 - Operator placement](https://github.com/php-fig/per-coding-style/blob/3.0.0/spec.md#64-operators-placement)
 
 When breaking a series of chained operations across multiple lines, the operator MUST be at the beginning of each line, not the end of each line, and all lines but the first MUST be indented.  Examples include `??` and ternary conditionals.
 


### PR DESCRIPTION
Following the decision in #138, all links in the migration guides should point to the target version on GitHub rather than the current version on the website, which always reflects the latest spec and can drift away from what the guide describes.

This PR updates migration-2.0.md to link to spec.md at the 2.0.0 tag and migration-3.0.md to link to spec.md at the 3.0.0 tag, covering both the per-section links and the canonical-source link in each intro.

Note that the Section 6.4 anchor in migration-3.0.md changes its fragment from `#64-operator-placement` to `#64-operators-placement` to match the heading on GitHub.