### PR TITLE
Change link to PHP coding standards

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -224,7 +224,7 @@ $result = match ($a) {
 
 ### 2.7 Naming
 
-This Standard RECOMMENDS following the [php-src coding standards](https://github.com/php/php-src/blob/master/CODING_STANDARDS.md#user-functionsmethods-naming-conventions) with regard to abbreviations and acronyms.
+This Standard RECOMMENDS following the [php-src coding standards](https://github.com/php/php-src/blob/PHP-8.5/CODING_STANDARDS.md#user-functionsmethods-naming-conventions) with regard to abbreviations and acronyms.
 
 Specifically:
 


### PR DESCRIPTION
Replaces the version from `master` with the version from `PHP-8.5`.

I think it's better to point to a more static version of the PHP coding standards than the version from the `master` branch. Using a tag instead of a branch would be even better.